### PR TITLE
move arithmetic parts of slice.reduce to cython

### DIFF
--- a/simple_slice_cython.pyx
+++ b/simple_slice_cython.pyx
@@ -4,6 +4,7 @@
 # cython: wraparound=False
 # cython: initializedcheck=False
 
+import cython
 from cpython cimport PyObject
 from libc.stdint cimport int64_t
 import sys
@@ -120,3 +121,140 @@ cdef class SimpleSliceCython:
 
     def __ne__(self, other):
         return not self == other
+
+
+
+@cython.cdivision(True)
+def _reduce_all_int(Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step):
+
+    assert step != 0
+
+    if start >= 0 and stop >= 0 or start < 0 and stop < 0:
+        if step > 0:
+            if stop <= start:
+                start, stop, step = 0, 0, 1
+            elif start >= 0 and start + step >= stop:
+                # Indexes 1 element. Start has to be >= 0 because a
+                # negative start could be less than the size of the
+                # axis, in which case it will clip and the single
+                # element will be element 0. We can only do that
+                # reduction if we know the shape.
+
+                # Note that returning Integer here is wrong, because
+                # slices keep the axis and integers remove it.
+                stop, step = start + 1, 1
+            elif start < 0 and start + step > stop:
+                # The exception is this case where stop is already
+                # start + 1.
+                step = stop - start
+            if start >= 0:
+                stop -= (stop - start - 1) % step
+        else: # step < 0
+            if stop >= start:
+                start, stop, step = 0, 0, 1
+            elif start < 0 and start + step <= stop:
+                if start < -1:
+                    stop, step = start + 1, 1
+                else: # start == -1
+                    stop, step = start - 1, -1
+            elif stop == start - 1:
+                stop, step = start + 1, 1
+            elif start >= 0 and start + step <= stop:
+                # Indexes 0 or 1 elements. We can't change stop
+                # because start might clip to a smaller true start if
+                # the axis is smaller than it, and increasing stop
+                # would prevent it from indexing an element in that
+                # case. The exception is the case right before this
+                # one (stop == start - 1). In that case start cannot
+                # clip past the stop (it always indexes the same one
+                # element in the cases where it indexes anything at
+                # all).
+                step = stop - start
+            if start < 0:
+                stop -= (stop - start + 1) % step
+    elif start >= 0 and stop < 0 and step < 0 and (start < -step or
+                                                   -stop - 1 < -step):
+        if stop == -1:
+            start, stop, step = 0, 0, 1
+        else:
+            step = max(-start - 1, stop + 1)
+    elif start < 0 and stop == 0 and step > 0:
+        start, stop, step = 0, 0, 1
+    elif start < 0 and stop >= 0 and step >= min(-start, stop):
+        step = min(-start, stop)
+        if start == -1 or stop == 1:
+            # Can only index 0 or 1 elements. We can either pick a
+            # version with positive start and negative step, or
+            # negative start and positive step. We prefer the former
+            # as it matches what is done for reduce() with a shape
+            # (start is always nonnegative).
+            assert step == 1
+            start, stop, step = stop - 1, start - 1, -1
+
+    return start, stop, step
+
+
+
+@cython.cdivision(True)
+def _reduce_with_size(Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step, Py_ssize_t size):
+
+    assert step != 0
+
+    if stop < -size:
+        stop = -size - 1
+
+    if size == 0:
+        start, stop, step = 0, 0, 1
+    elif step > 0:
+        # start cannot be None
+        if start < 0:
+            start = size + start
+        if start < 0:
+            start = 0
+        if start >= size:
+            start, stop, step = 0, 0, 1
+
+        if stop < 0:
+            stop = size + stop
+            if stop < 0:
+                stop = 0
+        else:
+            stop = min(stop, size)
+        stop -= (stop - start - 1) % step
+
+        if stop - start == 1:
+            # Indexes 1 element.
+            step = 1
+        elif stop - start <= 0:
+            start, stop, step = 0, 0, 1
+    else:
+        if start < 0:
+            if start >= -size:
+                start = size + start
+            else:
+                start, stop = 0, 0
+        if start >= 0:
+            start = min(size - 1, start)
+
+        if -size <= stop < 0:
+            stop += size
+
+        if stop >= 0:
+            if start - stop == 1:
+                stop, step = start + 1, 1
+            elif start - stop <= 0:
+                start, stop, step = 0, 0, 1
+            else:
+                stop += (start - stop - 1) % -step
+
+        # start >= 0
+        if (stop < 0 and start - size - stop <= -step
+            or stop >= 0 and start - stop <= -step):
+            stop, step = start + 1, 1
+        if stop < 0 and start % step != 0:
+            # At this point, negative stop is only necessary to index the
+            # first element. If that element isn't actually indexed, we
+            # prefer a nonnegative stop. Otherwise, stop will be -size - 1.
+            stop = start % -step - 1
+
+    return start, stop, step


### PR DESCRIPTION
This is just a demo: you can in principle move to cython not only whole functions/classes, but logical parts where variables are type-stable and use cython functions declarations as python/C trampolines. Then the code is basically the same, only compiled down to C (check `$ cython -a simple_slice.pyx`)

(not tested, not benchmarked. )
